### PR TITLE
Make -q be completely totally silent by using 'quiet' as a global variable

### DIFF
--- a/abcparse.c
+++ b/abcparse.c
@@ -37,6 +37,7 @@ static int keep_comment;
 /* global values */
 char *deco_tb[128];		/* decoration names */
 int severity;			/* error severity */
+extern int quiet;
 
 static int abc_vers;		/* abc version */
 static short abc_state;		/* parse state */
@@ -2883,6 +2884,7 @@ static void syntax(char *msg,
 	int n, len, m1, m2, pp;
 	int maxcol = 73;
 
+  if (quiet) { return; }
 	severity = 1;
 	n = q - abc_line;
 	len = strlen(abc_line);

--- a/subs.c
+++ b/subs.c
@@ -84,6 +84,8 @@ static short cw_tb[] = {
 	500,500,500,500,500,500,500,500,
 };
 
+extern int quiet;
+
 static struct u_ps {
 	struct u_ps *next;
 	char text[2];
@@ -107,6 +109,8 @@ void error(int sev,	/* 0: warning, 1: error */
 {
 	va_list args;
 static struct SYMBOL *t;
+
+  if(quiet) { return; }
 
 	if (t != info['T' - 'A']) {
 		char *p;


### PR DESCRIPTION
Although the -q option did silence some information, there was still a good amount of messages being printed to stderr. This patch makes 'quiet' a global variable in order to completely silence all messages.
